### PR TITLE
Rename from Cdn77CodingStandard to Cdn77

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ composer require --dev cdn77/coding-standard
 * Reference this coding standard in your `phpcs.xml.dist` (_check out [the one used in this project](phpcs.xml.dist)_):
 
 ```
-<rule ref="Cdn77CodingStandard"/>
+<rule ref="Cdn77"/>
 ```

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Cdn77CodingStandard\\": "src/Cdn77CodingStandard"
+            "Cdn77\\Sniffs\\": "src/Cdn77/Sniffs"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Cdn77CodingStandard\\Tests\\": "tests/"
+            "Cdn77\\Sniffs\\Tests\\": "tests/Sniffs"
         }
     },
     "require": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
 >
     <arg name="cache" value=".phpcs-cache"/>
 
-    <rule ref="Cdn77CodingStandard"/>
+    <rule ref="Cdn77"/>
 
     <file>src/</file>
     <file>tests/</file>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ parameters:
     bootstrap: %currentWorkingDirectory%/tests/bootstrap.php
     level: max
     excludes_analyse:
-        - %currentWorkingDirectory%/src/Cdn77CodingStandard/Sniffs/Arrays/ArrayDeclarationSniff.php # todo remove
+        - %currentWorkingDirectory%/src/Cdn77/Sniffs/Arrays/ArrayDeclarationSniff.php # todo remove
         - %currentWorkingDirectory%/tests/*/data/*
         - %currentWorkingDirectory%/vendor
     paths:

--- a/src/Cdn77/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/src/Cdn77/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cdn77CodingStandard\Sniffs\Arrays;
+namespace Cdn77\Sniffs\Arrays;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ruleset
-    name="Cdn77CodingStandard"
+    name="Cdn77"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd"
 >
@@ -24,20 +24,20 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration"/>
     </rule>
 
-    <rule ref="Cdn77CodingStandard.Arrays.ArrayDeclaration">
+    <rule ref="Cdn77.Arrays.ArrayDeclaration">
         <!-- Disable arrow alignment -->
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
         <!-- Uses indentation of only single space -->
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.KeyNotAligned"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.KeyNotAligned"/>
         <!-- Allow multiple values on a single line -->
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
         <!-- Disable alignment of braces -->
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
         <!-- Disable alignment of values with opening brace -->
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.ValueNotAligned"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.ValueNotAligned"/>
         <!-- Checked by SlevomatCodingStandard.Arrays.TrailingArrayComma.MissingTrailingComma -->
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.NoCommaAfterLast"/>
-        <exclude name="Cdn77CodingStandard.Arrays.ArrayDeclaration.NoComma"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.NoCommaAfterLast"/>
+        <exclude name="Cdn77.Arrays.ArrayDeclaration.NoComma"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>


### PR DESCRIPTION
This is shorter and should work fine. Same as `Doctrine`. WDYT?