### PR TITLE
Specify union type hint format

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,14 @@
 
     <rule ref="Cdn77"/>
 
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+        <properties>
+            <property name="withSpaces" value="no" />
+            <property name="shortNullable" value="no" />
+            <property name="nullPosition" value="last" />
+        </properties>
+    </rule>
+
     <file>src/</file>
     <file>tests/</file>
 


### PR DESCRIPTION
- no spaces between
- require `null`
- require `null` to be last

https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsuniontypehintformat-

-------

Requires `A|B|string|null`