### PR TITLE
Require Non-capturing catch

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,7 @@
     <rule ref="Cdn77"/>
 
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator" />
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
     <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
         <properties>


### PR DESCRIPTION
https://github.com/slevomat/coding-standard#slevomatcodingstandardexceptionsdisallownoncapturingcatch

```php
try {
    changeImportantData();
} catch (PermissionException) { // The intention is clear: exception details are irrelevant
    echo "You don't have permission to do this";
}
```