### PR TITLE
Disallow trailing comma in fcn declaration

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,8 @@
 
     <rule ref="Cdn77"/>
 
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration" />
+
     <file>src/</file>
     <file>tests/</file>
 


### PR DESCRIPTION
Disallows this

```php
function foo(
    $bar,
    $baz,
)
```

👇🏾 

```diff
function foo(
    $bar,
-    $baz,
+    $baz
)
```