### PR TITLE
Require trailing comma in multiline fcn declaration

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
 
     <rule ref="Cdn77"/>
 
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
     <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
         <properties>
             <property name="withSpaces" value="no" />


### PR DESCRIPTION
Requires this

```php
function foo(
    $bar,
    $baz,
)
```

----------

```diff
function foo(
    $bar,
-    $baz
+    $baz,
)
```

https://github.com/slevomat/coding-standard#slevomatcodingstandardfunctionsrequiretrailingcommaindeclaration-

Closes #53