### PR TITLE
Do not require space before `:` in return type hint declaration

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -80,12 +80,6 @@
     <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
 
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
-        <properties>
-            <property name="spacesCountBeforeColon" value="1"/>
-        </properties>
-    </rule>
-
     <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
         <properties>
             <property name="withSpaces" value="no" />


### PR DESCRIPTION
The whole php ecosystem uses `fn(): void`, there's no legit reason for us to use something else (currently `fn() : void`)

```diff
- fn() : never => never()
+ fn(): never => never()
``` 
