### PR TITLE
Disable var camelCaps name check (Squiz.NamingConventions.ValidVariableName.NotCamelCaps)

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -23,6 +23,9 @@
 
         <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
 
+        <!-- $_ variables are used to tell e.g. psalm that the variable is intentionally unused. -->
+        <exclude name="Squiz.NamingConventions.ValidVariableName.NotCamelCaps" />
+
         <!-- replaced by SlevomatCodingStandard.Commenting.RequireOneLineDocComment -->
         <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
     </rule>


### PR DESCRIPTION
This rule conflicts with e.g. psalm's `UnusedClosureParam`, see https://psalm.dev/docs/running_psalm/issues/UnusedClosureParam/