### PR TITLE
Require Nowdoc (Enable SlevomatCodingStandard.PHP.RequireNowdoc)

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -83,6 +83,7 @@
     <rule ref="SlevomatCodingStandard.Files.LineLength"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
+    <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc" />
 
     <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
         <properties>


### PR DESCRIPTION
Requires nowdoc if possible.

```diff
- $nowDoc = <<<TEXT
+ $nowDoc = <<<'TEXT'
text without special chars
TEXT;
```
https://github.com/slevomat/coding-standard/blob/master/README.md#slevomatcodingstandardphprequirenowdoc-