### PR TITLE
feat: disallow trailing comma in single line function declaration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require": {
         "php": "^8.0",
-        "doctrine/coding-standard": "^9.0"
+        "doctrine/coding-standard": "^9.0",
+        "slevomat/coding-standard": "^7.2"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -91,6 +91,11 @@
             <property name="ignoreComments" value="true" />
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
+        <properties>
+            <property name="onlySingleLine" value="true" />
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction" />
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc" />


### PR DESCRIPTION
```diff
- function foo(int $x,): void
+ function foo(int $x): void
{
}
```