### PR TITLE
refactor(cs): drop SlevomatCodingStandard.TypeHints.UnionTypeHintFormat rule

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -100,14 +100,6 @@
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc" />
 
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
-        <properties>
-            <property name="withSpaces" value="no" />
-            <property name="shortNullable" value="no" />
-            <property name="nullPosition" value="last" />
-        </properties>
-    </rule>
-
     <rule ref="Squiz.WhiteSpace.OperatorSpacing">
         <properties>
             <property name="ignoreNewlines" value="true"/>


### PR DESCRIPTION
Will be inherited https://github.com/doctrine/coding-standard/pull/266