### PR TITLE
refactor(cs): drop SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement rule

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -38,7 +38,6 @@
 
     <rule ref="Cdn77.NamingConventions.ValidVariableName"/>
 
-    <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
         <properties>
             <property name="groups" type="array" value="


### PR DESCRIPTION
Did not manage to trigger the rule, seems already covered by other rules.

```php
$array = [
    [
        1 => 2,
        3 => 4,
    ]];
```

<img width="833" alt="image" src="https://user-images.githubusercontent.com/327717/175879382-ed660434-9b53-4676-b518-26cb0824f29e.png">

https://github.com/slevomat/coding-standard/blob/master/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementErrors.php  
https://github.com/slevomat/coding-standard/blob/master/tests/Sniffs/Arrays/data/multiLineArrayEndBracketPlacementErrors.fixed.php
