### PR TITLE
refactor(cs): drop SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -92,7 +92,6 @@
             </property>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch" />
     <rule ref="SlevomatCodingStandard.Files.LineLength">
         <properties>
             <property name="ignoreComments" value="true" />


### PR DESCRIPTION
Introduced in https://github.com/doctrine/coding-standard/pull/281