### PR TITLE
refactor(cs): drop SlevomatCodingStandard.Classes.ParentCallSpacing

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -76,7 +76,6 @@
             "/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.PropertySpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion" />
     <!-- Not accepted in upstream https://github.com/doctrine/coding-standard/pull/280 -->


### PR DESCRIPTION
Ported to https://github.com/doctrine/coding-standard/pull/291