### PR TITLE
refactor: drop RequireOneLinePropertyDocComment exclusion

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -33,9 +33,6 @@
         <!-- replaced by Cdn77.NamingConventions.ValidVariableName -->
         <exclude name="Squiz.NamingConventions.ValidVariableName" />
 
-        <!-- replaced by SlevomatCodingStandard.Commenting.RequireOneLineDocComment -->
-        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
-
         <!-- Tools like PHPStan or Psalm check these better -->
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />


### PR DESCRIPTION
Resolved in https://github.com/doctrine/coding-standard/pull/294