### PR TITLE
feat: drop `SlevomatCodingStandard.Classes.RequireSingleLineMethodSignature`

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -78,8 +78,6 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion" />
-    <!-- Not accepted in upstream https://github.com/doctrine/coding-standard/pull/280 -->
-    <rule ref="SlevomatCodingStandard.Classes.RequireSingleLineMethodSignature"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing">
         <properties>
             <property name="linesCountAfterWhenLastInCaseOrDefault" value="0"/>


### PR DESCRIPTION
I often design a class and expect to add more dependencies in the future.

So I write this
```php
final class A
{
    public function __construct(
        private readonly Foo $foo,
    ) {
    }
```

in order to have similar looking diff later

```diff
private readonly Foo $foo,
+ private readonly Bar $bar,
```

mind the trailing comma after `$foo` is already there so the line has no change.

Unfortunately, with `RequireSingleLineMethodSignature` I'm forced to have ugly diffs:

```diff
-    public function __construct(private readonly Foo $foo)
+    public function __construct(
+        private readonly Foo $foo,
+        private readonly Bar $bar,
    ) {
    }
```

--------

https://github.com/doctrine/coding-standard/pull/280