### PR TITLE
feat: loosen method sorting rules

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -60,20 +60,9 @@
                 static constructors,
                 destructor,
                 magic methods,
-                public static abstract methods,
-                public abstract methods,
-                public static final methods,
-                public static methods,
-                public final methods,
-                public methods,
-                protected static abstract methods,
-                protected abstract methods,
-                protected static final methods,
-                protected static methods,
-                protected final methods,
-                protected methods,
-                private static methods,
-                private methods,
+                all public methods,
+                all protected methods,
+                all private methods,
             "/>
         </properties>
     </rule>


### PR DESCRIPTION
# Motivation

We use data providers in phpunit that are manually located bellow the test or bellow the set of tests that use it.

```
testA
providerA
testB
providerB
testCommonFoo
testCommonBar
providerCommon
```

Since phpunit v10 requires data providers to be static, the ClassStructure rule would detach them from the actual test resulting in:

```
providerA
providerB
providerCommon
testA
testB
testCommonFoo
testCommonBar
```

Also there has been a lot of discussion in past on how to order these methods.

# Proposal

I propose to loosen the rule and sort methods only by visibility. Specifically:

1. public
2. protected
3. private

The remaining attributes like `abstract`, `final` and `static` will not be taken into account and left for the user to do whatever he considers the best.