### PR TITLE
feat: allow multi line arrays with single value

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -33,6 +33,9 @@
         <!-- replaced by Cdn77.NamingConventions.ValidVariableName -->
         <exclude name="Squiz.NamingConventions.ValidVariableName" />
 
+        <!-- Allow single value arrays to span across multiple lines -->
+        <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed" />
+
         <!-- Tools like PHPStan or Psalm check these better -->
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />


### PR DESCRIPTION
We often resolve array keys or array values using value objects or method calls, which often force us to span the key and  value across multiple lines, when this rule is enabled such syntax is often forcing us to extract the key, the value or both to a variable when the array only contains a single value. E.g.:

Before:
```
final class A {
    public function getArray(): array
    {
        $value = $this->resolveFunctionKeyValueForArray($withSomeLongArgumentName);
    
        return [
            SomeVeryLongClassNameWithKeyConst::KeySomeLongParameter => $value,
        ];
    }
}
```

After:
```
final class A {
    public function getArray(): array
    {
        return [
            SomeVeryLongClassNameWithKeyConst::KeySomeLongParameter
            => $this->resolveFunctionKeyValueForArray($withSomeLongArgumentName),
        ];
    }
}
```