### PR TITLE
fix: do not pass array of values to a property using a comma-separated string

### DIFF
--- a/src/Cdn77/ruleset.xml
+++ b/src/Cdn77/ruleset.xml
@@ -45,26 +45,26 @@
 
     <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
         <properties>
-            <property name="groups" type="array" value="
-                uses,
-                public constants,
-                protected constants,
-                private constants,
-                enum cases,
-                public static properties,
-                protected static properties,
-                private static properties,
-                public properties,
-                protected properties,
-                private properties,
-                constructor,
-                static constructors,
-                destructor,
-                magic methods,
-                all public methods,
-                all protected methods,
-                all private methods,
-            "/>
+            <property name="groups" type="array">
+                <element value="uses" />
+                <element value="public constants" />
+                <element value="protected constants" />
+                <element value="private constants" />
+                <element value="enum cases" />
+                <element value="public static properties" />
+                <element value="protected static properties" />
+                <element value="private static properties" />
+                <element value="public properties" />
+                <element value="protected properties" />
+                <element value="private properties" />
+                <element value="constructor" />
+                <element value="static constructors" />
+                <element value="destructor" />
+                <element value="magic methods" />
+                <element value="all public methods" />
+                <element value="all protected methods" />
+                <element value="all private methods" />
+            </property>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion" />


### PR DESCRIPTION
It was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.