### PR TITLE
Drop PHP 8.3 support, add PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           coverage: none
           extensions: json
           tools: cs2pr
@@ -41,7 +41,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           coverage: none
           extensions: json
           tools: cs2pr
@@ -59,13 +59,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3"
           - "8.4"
+          - "8.5"
         dependencies:
           - "highest"
         include:
           - dependencies: "lowest"
-            php-version: "8.3"
+            php-version: "8.4"
     name: PHP ${{ matrix.php-version }} Test ${{ matrix.dependencies }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "doctrine/coding-standard": "^14",
         "slevomat/coding-standard": "^8.23.0",
         "squizlabs/php_codesniffer": "^4"


### PR DESCRIPTION
- Update composer.json minimum PHP requirement from ^8.3 to ^8.4
- Update CI coding-standard and phpstan jobs to use PHP 8.4
- Update PHPUnit matrix: test PHP 8.4 and 8.5 (was 8.3 and 8.4)
- Run lowest-dependency tests on PHP 8.4 instead of 8.3

https://claude.ai/code/session_01MUjCvaa5dkrD6v9nV6DkLy