### PR TITLE
chore(deps): require slevomat/coding-standard ^8.30

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.4",
         "doctrine/coding-standard": "^14",
-        "slevomat/coding-standard": "^8.23.0",
+        "slevomat/coding-standard": "^8.30",
         "squizlabs/php_codesniffer": "^4"
     },
     "require-dev": {


### PR DESCRIPTION
Updates the root Composer constraint for slevomat/coding-standard to ^8.30.